### PR TITLE
Feature/package update check

### DIFF
--- a/src/universal_mcp/applications/__init__.py
+++ b/src/universal_mcp/applications/__init__.py
@@ -65,8 +65,7 @@ def _check_for_package_update(slug_clean: str) -> bool:
         repo_url = f"https://github.com/universal-mcp/{slug_clean}.git"
         result = subprocess.run(
             ["git", "ls-remote", repo_url, "HEAD"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             check=True,
             text=True
         )
@@ -84,7 +83,7 @@ def _check_for_package_update(slug_clean: str) -> bool:
             logger.info(f"No version file found for '{slug_clean}'. Update needed.")
             return True
 
-        with open(version_file, "r") as f:
+        with open(version_file) as f:
             local_commit = f.read().strip()
 
         if local_commit != latest_commit:


### PR DESCRIPTION
Originally, the system only installed a missing package if it wasn’t found locally, but it **never checked for updates** once the package was installed. This meant that even if the source repository had new changes, the application would continue using an outdated version.

To improve this:
- I added logic to **check the latest commit hash** on GitHub using `git ls-remote`.
- A new function compares this hash to a locally stored commit in `_commit.txt` inside the package directory.
- If the hashes differ, the package is **forcibly reinstalled** using `pip`, and the latest commit hash is updated.
- This ensures that the package is **only updated when necessary**, maintaining freshness without unnecessary reinstallations.