### PR TITLE
feat: Add OpenTelemetry support and improve logging

### DIFF
--- a/playground/__main__.py
+++ b/playground/__main__.py
@@ -4,10 +4,36 @@ import sys
 import time
 
 from loguru import logger
+from opentelemetry import trace
+
+from universal_mcp.config import ServerConfig
+from universal_mcp.logger import setup_logger
+
+tracer = trace.get_tracer(__name__)
 
 
 def main():
-    processes = []
+    # --- OpenTelemetry Setup ---
+    app_name = "universal-mcp-playground"
+    otel_endpoint = None
+    try:
+        # Try to load config to get OTel endpoint
+        # Assuming local_config.json is the source for server config in playground
+        if os.path.exists("local_config.json"):
+            server_config = ServerConfig.load_json_config("local_config.json")
+            otel_endpoint = server_config.otel_exporter_otlp_endpoint
+            app_name = server_config.name or app_name # Use server name if available
+        else:
+            logger.info("local_config.json not found, OpenTelemetry will not be initialized from server config.")
+    except Exception as e:
+        logger.warning(f"Failed to load ServerConfig for OpenTelemetry: {e}")
+
+    # Setup logger (which also sets up OTel if endpoint is available)
+    setup_logger(otel_exporter_otlp_endpoint=otel_endpoint, app_name=app_name)
+    # --- End OpenTelemetry Setup ---
+
+    with tracer.start_as_current_span("app.startup"):
+        processes = []
 
     # Start MCP server first
     # Ask the user if they want to run the MCP server
@@ -18,22 +44,22 @@ def main():
         time.sleep(6)  # Give MCP server time to start
         logger.info("MCP server started")
 
-    streamlit_cmd = [
-        sys.executable,
-        "-m",
-        "streamlit",
-        "run",
-        os.path.join("playground", "streamlit.py"),
-    ]
-    processes.append(subprocess.Popen(streamlit_cmd, env=os.environ))
-    logger.info("Streamlit app started")
-    try:
-        for p in processes:
-            p.wait()
-    except KeyboardInterrupt:
-        for p in processes:
-            p.terminate()
-            p.wait()
+        streamlit_cmd = [
+            sys.executable,
+            "-m",
+            "streamlit",
+            "run",
+            os.path.join("playground", "streamlit.py"),
+        ]
+        processes.append(subprocess.Popen(streamlit_cmd, env=os.environ))
+        logger.info("Streamlit app started")
+        try:
+            for p in processes:
+                p.wait()
+        except KeyboardInterrupt:
+            for p in processes:
+                p.terminate()
+                p.wait()
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
     "pyyaml>=6.0.2",
     "rich>=14.0.0",
     "typer>=0.15.2",
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp",
 ]
 
 [project.optional-dependencies]

--- a/src/universal_mcp/config.py
+++ b/src/universal_mcp/config.py
@@ -61,6 +61,9 @@ class ServerConfig(BaseSettings):
     store: StoreConfig | None = Field(default=None, description="Default store configuration")
     debug: bool = Field(default=False, description="Enable debug mode")
     log_level: str = Field(default="INFO", description="Logging level")
+    otel_exporter_otlp_endpoint: str | None = Field(
+        default=None, description="OpenTelemetry OTLP exporter endpoint", alias="OTEL_EXPORTER_OTLP_ENDPOINT"
+    )
 
     @field_validator("log_level", mode="before")
     def validate_log_level(cls, v: str) -> str:

--- a/src/universal_mcp/logger.py
+++ b/src/universal_mcp/logger.py
@@ -1,8 +1,20 @@
 import sys
 from datetime import datetime
 from pathlib import Path
+import logging
 
 from loguru import logger
+from opentelemetry import trace
+from opentelemetry import _logs as otel_logs # Renamed to avoid conflict
+from opentelemetry.trace import set_tracer_provider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk._logs import LoggerProvider, LogRecord as OpenTelemetryLogRecord
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter # Corrected import
+from opentelemetry._logs import set_logger_provider, SeverityNumber # Renamed to avoid conflict
 
 
 def get_log_file_path(app_name: str = "universal-mcp") -> Path:
@@ -27,6 +39,8 @@ def setup_logger(
     compression: str = "zip",
     level: str = "INFO",
     format: str = "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
+    otel_exporter_otlp_endpoint: str | None = None,
+    app_name: str = "universal-mcp",
 ) -> None:
     """Setup the logger with both stderr and optional file logging with rotation.
 
@@ -37,9 +51,72 @@ def setup_logger(
         compression: Compression format for rotated logs ("zip", "gz", or None).
         level: Minimum logging level.
         format: Log message format string.
+        otel_exporter_otlp_endpoint: Optional OTLP endpoint for OpenTelemetry.
+        app_name: Name of the application, used for OpenTelemetry service.name.
     """
     # Remove default handler
     logger.remove()
+
+    if otel_exporter_otlp_endpoint:
+        resource = Resource(attributes={"service.name": app_name})
+
+        # Setup Tracing
+        tracer_provider = TracerProvider(resource=resource)
+        span_exporter = OTLPSpanExporter(endpoint=otel_exporter_otlp_endpoint)
+        tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+        set_tracer_provider(tracer_provider)
+
+        # Setup Logging
+        logger_provider = LoggerProvider(resource=resource)
+        log_exporter = OTLPLogExporter(endpoint=otel_exporter_otlp_endpoint)
+        logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+        set_logger_provider(logger_provider) # Use the imported set_logger_provider
+
+        # Custom Loguru Sink for OpenTelemetry
+        class OtelLoguruSink:
+            def __init__(self, otel_logger_provider: LoggerProvider, app_name: str):
+                self.otel_logger = otel_logger_provider.get_logger(app_name)
+                # Mapping Loguru levels to OpenTelemetry SeverityNumber
+                self.level_mapping = {
+                    "TRACE": SeverityNumber.TRACE,
+                    "DEBUG": SeverityNumber.DEBUG,
+                    "INFO": SeverityNumber.INFO,
+                    "SUCCESS": SeverityNumber.INFO2, # Or map to INFO
+                    "WARNING": SeverityNumber.WARN,
+                    "ERROR": SeverityNumber.ERROR,
+                    "CRITICAL": SeverityNumber.FATAL,
+                }
+
+            def write(self, message):
+                record = message.record
+                severity_number = self.level_mapping.get(record["level"].name, SeverityNumber.UNSPECIFIED)
+
+                log_record = OpenTelemetryLogRecord(
+                    timestamp=int(record["time"].timestamp() * 1e9), # nanoseconds
+                    observed_timestamp=int(datetime.now().timestamp() * 1e9), # nanoseconds
+                    severity_text=record["level"].name,
+                    severity_number=severity_number,
+                    body=record["message"],
+                    resource=resource, # Associate with the same resource
+                    attributes={
+                        "loguru.file.name": record["file"].name,
+                        "loguru.file.path": str(record["file"].path),
+                        "loguru.function": record["function"],
+                        "loguru.line": record["line"],
+                        "loguru.module": record["module"],
+                        "loguru.name": record["name"],
+                        "loguru.thread.id": record["thread"].id,
+                        "loguru.thread.name": record["thread"].name,
+                        "loguru.process.id": record["process"].id,
+                        "loguru.process.name": record["process"].name,
+                        **record.get("extra", {}), # Include any extra data
+                    }
+                )
+                self.otel_logger.emit(log_record)
+
+        logger.add(OtelLoguruSink(logger_provider, app_name), level=level, format=format, enqueue=True)
+
+
 
     # Add stderr handler
     logger.add(


### PR DESCRIPTION
This commit introduces OpenTelemetry integration for tracing and logging.

Key changes:

- Added OpenTelemetry dependencies (`opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp`).
- Updated `ServerConfig` to allow configuring an OTLP exporter endpoint via `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable or `otel_exporter_otlp_endpoint` in the config file.
- Enhanced `setup_logger` in `src/universal_mcp/logger.py`:
    - Initializes OpenTelemetry tracing and logging if an OTLP endpoint is provided.
    - Sets up OTLP exporters for both traces and logs.
    - Implemented a custom Loguru sink (`OtelLoguruSink`) to bridge Loguru logs to the OpenTelemetry logging SDK, ensuring existing Loguru logs are also exported.
- Instrumented key application areas:
    - `playground/__main__.py`: Added a span "app.startup" to trace application initialization. `setup_logger` is called here, loading the OTel configuration.
    - `src/universal_mcp/tools/manager.py`: Added a span "tool.run" for each tool call in the `call_tool` method, including "tool.name" and "tool.status" attributes, and exception recording.
- Reviewed existing log levels across the application, confirming their appropriateness.
- Added unit tests for `setup_logger` in `src/tests/test_logger.py`:
    - Verifies OTel initialization based on endpoint presence.
    - Tests the OTel SDK pipeline and Loguru sink integration using in-memory exporters. (Note: I structurally validated the tests, but could not run them in the environment due to Python version constraints.)

This integration allows for better observability of the application, enabling distributed tracing and centralized logging when an OpenTelemetry collector is configured.