### PR TITLE
feat(applications): Implement flexible app loading from local and remote sources

### DIFF
--- a/src/universal_mcp/config.py
+++ b/src/universal_mcp/config.py
@@ -72,6 +72,22 @@ class AppConfig(BaseModel):
         default=None,
         description="A list of specific actions or tools provided by this application that should be exposed. If None or empty, all tools from the application might be exposed by default, depending on the application's implementation.",
     )
+    
+    source_type: Literal["package", "local_folder", "remote_zip"] = Field(
+        default="package",
+        description="The source of the application. 'package' (default) installs from a repository, 'local_folder' loads from a local path, 'remote_zip' downloads and extracts a project zip."
+    )
+    source_path: str | None = Field(
+        default=None,
+        description="The path or URL for 'local_folder' or 'remote_zip' source types."
+    )
+
+    @model_validator(mode="after")
+    def check_path_for_non_package_sources(self) -> Self:
+        if self.source_type in ["local_folder", "remote_zip"]:
+            if not self.source_path:
+                raise ValueError(f"'source_path' is required for source_type '{self.source_type}'")
+        return self
 
 
 class ServerConfig(BaseSettings):

--- a/src/universal_mcp/servers/server.py
+++ b/src/universal_mcp/servers/server.py
@@ -5,7 +5,7 @@ from loguru import logger
 from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
-from universal_mcp.applications import BaseApplication, app_from_slug
+from universal_mcp.applications import BaseApplication, app_from_config
 from universal_mcp.config import AppConfig, ServerConfig
 from universal_mcp.exceptions import ConfigurationError, ToolError
 from universal_mcp.integrations import AgentRIntegration, integration_from_config
@@ -43,7 +43,7 @@ def load_from_local_config(config: ServerConfig, tool_manager: ToolManager) -> N
                     integration = integration_from_config(app_config.integration, store=store if config.store else None)
                 except Exception as e:
                     logger.error(f"Failed to setup integration for {app_config.name}: {e}", exc_info=True)
-            app = app_from_slug(app_config.name)(integration=integration)
+            app = app_from_config(app_config)(integration=integration)
             tool_manager.register_tools_from_app(app, app_config.actions)
             logger.info(f"Loaded app: {app_config.name}")
         except Exception as e:
@@ -62,7 +62,7 @@ def load_from_agentr_server(client: AgentrClient, tool_manager: ToolManager) -> 
                     if app_config.integration
                     else None
                 )
-                app_instance = app_from_slug(app_config.name)(integration=integration)
+                app_instance = app_from_config(app_config)(integration=integration)
                 tool_manager.register_tools_from_app(app_instance, app_config.actions)
                 logger.info(f"Loaded app from AgentR: {app_config.name}")
             except Exception as e:


### PR DESCRIPTION
feat(applications): Implement flexible app loading from local and remote sources

This commit introduces a more robust and flexible mechanism for loading Universal MCP applications, addressing a key developer workflow limitation. Previously, all applications had to be installed as packages from a repository, which is inefficient for local development and testing.

The key changes include:

- Enhanced `AppConfig` in `config.py` with `source_type` and `source_path` fields to explicitly define the origin of an application ('package', 'local_folder', 'remote_zip').

- Refactored the core loading logic in `applications/__init__.py`. The former `app_from_slug` function is now `app_from_config`, which intelligently handles each source type.

- Implemented a handler for `local_folder` that adds the project's `src` to `sys.path` and imports the module directly, bypassing installation.

- Added a handler for `remote_zip` that downloads, caches, and extracts a zipped project, then treats it as a local folder. This supports full project structures with dependencies.

- Updated server loading logic in `servers/server.py` to use the new `app_from_config` function, ensuring seamless integration.